### PR TITLE
fix typo for `error-text` in typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -67,7 +67,7 @@ declare module 'nexmo' {
 
     export interface MessageError {
         status: MessageRequestResponseStatusCode;
-        error_text: string;
+        'error-text': string;
     }
     
     export interface MessageRequestResponse {


### PR DESCRIPTION
Hi,

It looks like there is a typo in the typings. It doesn't correspond to what I receive from the API.
`error_text` should be `error-text`.